### PR TITLE
Bring in emoji rating widget

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,15 +1,21 @@
-
+``;
 import { setRating, logView } from "./util/api";
 import Config from "./background/config";
 import Cache, { CacheValue } from "./background/Cache";
-import { ViewResponse, ObservedRatingUpdateResponse, SaveRatingResponse, BackgroundMessage, SaveRatingRequest } from "./models/messageTypes";
+import {
+  ViewResponse,
+  ObservedRatingUpdateResponse,
+  SaveRatingResponse,
+  BackgroundMessage,
+  SaveRatingRequest
+} from "./models/messageTypes";
 import Rating from "./models/Rating";
 
 const config = new Config();
 
 function onLoad(
   messageCallback: (msg: ViewResponse) => void,
-  cachedValue:  CacheValue<Rating>,
+  cachedValue: CacheValue<Rating>,
   prPath: string
 ) {
   const rating = cachedValue.get();
@@ -23,19 +29,19 @@ function onLoad(
 
   logView(config.apiKey, prPath)
     .then(resp => {
+      console.log(resp);
       cachedValue.set(resp.rating);
-      if (!resp.rating) {
-        messageCallback({
-          type: "ViewResponse",
-          rating: null,
-        });
-      }
+
+      messageCallback({
+        type: "ViewResponse",
+        rating: resp.rating
+      });
     })
     .catch((reason: Error) => {
       messageCallback({
         type: "ViewResponse",
         rating: cachedValue.get(),
-        error: reason.message,
+        error: reason.message
       });
     });
 }
@@ -59,7 +65,7 @@ function receiveUpdate(
     .catch((reason: Error) => {
       messageCallback({
         type: "SaveRatingResponse",
-        error: reason.message,
+        error: reason.message
       });
     });
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -29,7 +29,6 @@ function onLoad(
 
   logView(config.apiKey, prPath)
     .then(resp => {
-      console.log(resp);
       cachedValue.set(resp.rating);
 
       messageCallback({

--- a/src/components/overlay/HeartbeatFAB.tsx
+++ b/src/components/overlay/HeartbeatFAB.tsx
@@ -26,7 +26,6 @@ class HeartbeatFAB extends React.Component<IHeartbeatFABProps> {
       return null;
     }
 
-    console.log("render", this.props.pullRequestStore.requestInProgress);
     let icon = <FavoriteBorderIcon fontSize="large" />;
 
     if (

--- a/src/components/overlay/RatingDialog.tsx
+++ b/src/components/overlay/RatingDialog.tsx
@@ -5,13 +5,27 @@ import PullRequestStore from "../../stores/PullRequestStore";
 import RatingForm from "./RatingForm";
 import ErrorNotice from "./ErrorNotice";
 import { withStyles } from "@material-ui/core";
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 const Dialog = withStyles({
   root: {
     maxWidth: "400px",
-    marginRight: "1em"
+    marginRight: "1em",
+    position: "relative"
   }
 })(Paper);
+
+const LoadingOverlay = (<div style={{
+  position: "absolute",
+  width: "100%",
+  height: "100%",
+  backgroundColor: "white",
+  opacity: 0.8,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 9999
+}}><CircularProgress /></div>);
 
 interface IRatingDialogProps {
   pullRequestStore?: PullRequestStore;
@@ -28,6 +42,7 @@ class RatingDialog extends React.Component<IRatingDialogProps> {
         <Dialog
           elevation={12}
         >
+          {this.props.pullRequestStore!.requestInProgress ? LoadingOverlay : null}
           {this.props.pullRequestStore!.authError ? (
             <ErrorNotice />
           ) : (

--- a/src/components/overlay/RatingForm.tsx
+++ b/src/components/overlay/RatingForm.tsx
@@ -20,7 +20,7 @@ class RatingForm extends React.Component<IRatingFormProps> {
         <Typography variant="h5" gutterBottom>Hecate Heartbeat</Typography>
         <Typography variant="body2">
           Rate this pull request for both the quality of the outcome and the
-          quality of the collaboration by clicking on the emojis below.
+          quality of the collaboration by clicking on the emojis below. 
         </Typography>
         {this.props.pullRequestStore!.requestError && (
           <Typography variant="body2" color="error">

--- a/src/components/overlay/RatingForm.tsx
+++ b/src/components/overlay/RatingForm.tsx
@@ -20,9 +20,7 @@ class RatingForm extends React.Component<IRatingFormProps> {
         <Typography variant="h5" gutterBottom>Hecate Heartbeat</Typography>
         <Typography variant="body2">
           Rate this pull request for both the quality of the outcome and the
-          quality of the collaboration. Leave the slider in the centre for a
-          neutral rating, push to the right for positive, and to the left for
-          negative.
+          quality of the collaboration by clicking on the emojis below.
         </Typography>
         {this.props.pullRequestStore!.requestError && (
           <Typography variant="body2" color="error">

--- a/src/components/overlay/RatingFormFields.tsx
+++ b/src/components/overlay/RatingFormFields.tsx
@@ -3,10 +3,6 @@ import { Component, Fragment } from "react";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import TextField from "@material-ui/core/TextField";
-import FormControl from "@material-ui/core/FormControl";
-import InputLabel from "@material-ui/core/InputLabel";
-import Select from "@material-ui/core/Select";
-import MenuItem from "@material-ui/core/MenuItem";
 import BuildIcon from "@material-ui/icons/Build";
 import PeopleIcon from "@material-ui/icons/People";
 import Slider from "./Slider";
@@ -34,6 +30,7 @@ class RatingFormFields extends Component<IRatingFormProps> {
     key: "outcomeScore" | "processScore"
   ): (event: React.ChangeEvent, value: number) => void {
     return (event, value) => {
+      console.log("newSliderValue", key, value)
       this.props.pullRequestStore.setRatingProperty<
         "outcomeScore" | "processScore"
       >(key, value);
@@ -54,20 +51,38 @@ class RatingFormFields extends Component<IRatingFormProps> {
             </Typography>
           </Grid>
           <Grid item xs>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <BuildIcon />
+              <Typography
+                variant="subtitle1"
+                component="span"
+                style={{ marginLeft: "1.2em" }}
+              >
+                Outcome
+              </Typography>
+            </div>
             <Slider
               value={this.props.pullRequestStore.rating.outcomeScore}
               onChange={this.changeSlider("outcomeScore")}
-            >
-              <BuildIcon fontSize="large" />
-            </Slider>
+              key={this.props.pullRequestStore.rating.outcomeScore}
+            />
           </Grid>
           <Grid item xs>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <PeopleIcon />
+              <Typography
+                variant="subtitle1"
+                component="span"
+                style={{ marginLeft: "1.2em" }}
+              >
+                Process
+              </Typography>
+            </div>
             <Slider
               value={this.props.pullRequestStore.rating.processScore}
               onChange={this.changeSlider("processScore")}
-            >
-              <PeopleIcon fontSize="large" />
-            </Slider>
+              key={this.props.pullRequestStore.rating.processScore}
+            />
           </Grid>
           {/* <Grid item xs={6} sm={12}>
             <TextField

--- a/src/components/overlay/RatingFormFields.tsx
+++ b/src/components/overlay/RatingFormFields.tsx
@@ -30,7 +30,6 @@ class RatingFormFields extends Component<IRatingFormProps> {
     key: "outcomeScore" | "processScore"
   ): (event: React.ChangeEvent, value: number) => void {
     return (event, value) => {
-      console.log("newSliderValue", key, value)
       this.props.pullRequestStore.setRatingProperty<
         "outcomeScore" | "processScore"
       >(key, value);

--- a/src/components/overlay/RatingFormFields.tsx
+++ b/src/components/overlay/RatingFormFields.tsx
@@ -75,7 +75,7 @@ class RatingFormFields extends Component<IRatingFormProps> {
                 component="span"
                 style={{ marginLeft: "1.2em" }}
               >
-                Process
+                Collaboration
               </Typography>
             </div>
             <Slider

--- a/src/components/overlay/Slider.tsx
+++ b/src/components/overlay/Slider.tsx
@@ -1,25 +1,105 @@
 import * as React from "react";
-import { SFC, ReactChild } from "react";
-import MuiSlider from "@material-ui/lab/Slider";
-import { withStyles } from "@material-ui/core/styles";
 
 interface ISliderProps {
-  children: ReactChild;
-  value: number;
-  onChange: (event: React.ChangeEvent<HTMLInputElement>, value: number) => void;
+  value?: number;
+  onChange: (event: React.ChangeEvent<Element>, value: number) => void;
 }
 
-const StyledSlider = withStyles({
-  root: {
-    padding: "22px 0"
-  }
-})(MuiSlider);
+interface ISliderState {
+  percentage?: number;
+  clicked: boolean;
+}
 
-const Slider: SFC<ISliderProps> = ({ children, onChange, value }) => (
-  <React.Fragment>
-    {children}
-    <StyledSlider min={-3} max={3} step={1} value={value} onChange={onChange} />
-  </React.Fragment>
-);
+class Slider extends React.Component<ISliderProps, ISliderState> {
+  constructor(props: ISliderProps) {
+    super(props);
+    if (props.value) {
+      this.state = {
+        percentage: parseFloat(props.value.toString()) * 25 + 50,
+        clicked: true
+      };
+    } else {
+      this.state = {
+        clicked: false
+      };
+    }
+  }
+
+  score(val?: number) {
+    const percentage = val || this.state.percentage;
+    if (percentage) {
+      const shifted = percentage - 50;
+      const clamped = shifted / 25;
+      return clamped;
+    }
+  }
+
+  render() {
+    return (
+      <div
+        style={{
+          position: "relative",
+          display: "inline-block",
+          overflow: "hidden"
+        }}
+      >
+        <div
+          style={{
+            pointerEvents: "none",
+            position: "absolute",
+            height: "100%",
+            right: 0,
+            backgroundColor: "white",
+            opacity: 0.6,
+            width: `${
+              this.state.percentage ? 100 - this.state.percentage : 100
+            }%`
+          }}
+        />
+        <div
+          style={{
+            display: "inline-block",
+            cursor: "pointer",
+            fontSize: "1.8em"
+          }}
+          onMouseMove={this.mouseMove}
+          onClick={this.lockItIn}
+        >
+          😬😒😐😊🤩
+        </div>
+      </div>
+    );
+  }
+
+  percentage(e: any) {
+    const boundingRect: DOMRect = e.target.getBoundingClientRect();
+    const x = e.clientX - boundingRect.x;
+    const width = boundingRect.width;
+
+    const percentage = Math.max(
+      0,
+      Math.min(100, Math.round((x / width) * 100))
+    );
+
+    return percentage;
+  }
+
+  mouseMove = (e: any) => {
+    if (this.state.clicked) {
+      return;
+    }
+
+    const percentage = this.percentage(e);
+    if (percentage !== this.state.percentage) {
+      this.setState({ percentage });
+    }
+  };
+
+  lockItIn = (e: any) => {
+    const percentage = this.percentage(e);
+    this.props.onChange(e, this.score(percentage));
+    this.setState({ clicked: true, percentage });
+  };
+}
 
 export default Slider;

--- a/src/components/overlay/Slider.tsx
+++ b/src/components/overlay/Slider.tsx
@@ -40,7 +40,8 @@ class Slider extends React.Component<ISliderProps, ISliderState> {
         style={{
           position: "relative",
           display: "inline-block",
-          overflow: "hidden"
+          overflow: "hidden",
+          marginTop: "0.4em"
         }}
       >
         <div

--- a/src/models/Rating.ts
+++ b/src/models/Rating.ts
@@ -1,8 +1,8 @@
 import { decorate, observable } from "mobx";
 
 class Rating {
-    public outcomeScore: number = 0;
-    public processScore: number = 0;
+    public outcomeScore?: number;
+    public processScore?: number;
     public labels: string[] = [];
     public notes?: string;
     public remindOnDate?: string; // TODO make date?

--- a/src/stores/PullRequestStore.ts
+++ b/src/stores/PullRequestStore.ts
@@ -96,6 +96,9 @@ class PullRequestStore {
           this.requestError = msg.error;
         } else if (msg.rating) {
           this.serverRating = msg.rating;
+          if (this.requestInProgress) {
+            this.rating = this.serverRating;
+          }
         }
         break;
     }

--- a/src/stores/PullRequestStore.ts
+++ b/src/stores/PullRequestStore.ts
@@ -103,7 +103,6 @@ class PullRequestStore {
         break;
     }
     this.requestInProgress = false;
-    console.log("requestInProgress", this.requestInProgress);
   }
 
   private connectPort() {

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -16,7 +16,7 @@ function fetchJson(
   path: string,
   options: IRequestOptions = {}
 ): Promise<any> {
-  console.log("about to fetch", apiHost, path);
+  console.log("about to fetch", apiHost, path, options);
   return fetch(`${apiHost}${path}`, {
     ...options,
     headers: {


### PR DESCRIPTION
The earliest version of the heartbeat widget used emojis which were charming and fun but also janky.

The next version used the stock material UI sliders which were lame and unexciting. @daveslutzkin complained.

This version brings back emojis but does it real good.

![image](https://user-images.githubusercontent.com/4092/51528810-9aecac00-1e8b-11e9-93fc-2bc349709e07.png)
